### PR TITLE
Feature to toggle whether to use IE6 fallback theme

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -28,6 +28,7 @@
 			keyboard_shortcuts: true, /* Set to false if you open forms inside prettyPhoto */
 			changepicturecallback: function(){}, /* Called everytime an item is shown/changed */
 			callback: function(){}, /* Called when prettyPhoto is closed */
+			ie6_fallback: true,
 			markup: '<div class="pp_pic_holder"> \
 						<div class="ppt">&nbsp;</div> \
 						<div class="pp_top"> \
@@ -132,7 +133,7 @@
 		$.prettyPhoto.initialize = function() {
 			settings = pp_settings;
 			
-			if($.browser.msie && parseInt($.browser.version) == 6) settings.theme = "light_square"; // Fallback to a supported theme for IE6
+			if(settings.ie6_fallback && $.browser.msie && parseInt($.browser.version) == 6) settings.theme = "light_square"; // Fallback to a supported theme for IE6
 			
 			// Find out if the picture is part of a set
 			theRel = $(this).attr('rel');


### PR DESCRIPTION
Hi Stephane,

We wanted to use the same theme for IE6 as with the other browsers so I added a setting that allows one to toggle whether they use fallback or not.

Default is set to true, so plugin has same default functionality as before.

-Bri
