### PR TITLE
Update Facebook Like button when browsing gallery.

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -86,7 +86,8 @@
 			iframe_markup: '<iframe src ="{path}" width="{width}" height="{height}" frameborder="no"></iframe>',
 			inline_markup: '<div class="pp_inline">{content}</div>',
 			custom_markup: '',
-			social_tools: '<div class="pp_social"><div class="twitter"><a href="http://twitter.com/share" class="twitter-share-button" data-count="none">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script></div><div class="facebook"><iframe src="http://www.facebook.com/plugins/like.php?locale=en_US&href='+location.href+'&amp;layout=button_count&amp;show_faces=true&amp;width=500&amp;action=like&amp;font&amp;colorscheme=light&amp;height=23" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:500px; height:23px;" allowTransparency="true"></iframe></div></div>' /* html or false to disable */
+			social_tools: '<div class="pp_social"><div class="twitter"><a href="http://twitter.com/share" class="twitter-share-button" data-count="none">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script></div><div class="facebook">{facebook_like}</div></div>', /* html or false to disable */
+			facebook_like: '<iframe src="http://www.facebook.com/plugins/like.php?locale=en_US&href={location_href}&amp;layout=button_count&amp;show_faces=true&amp;width=500&amp;action=like&amp;font&amp;colorscheme=light&amp;height=23" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:500px; height:23px;" allowTransparency="true"></iframe>'
 		}, pp_settings);
 		
 		// Global variables accessible only by prettyPhoto
@@ -192,6 +193,10 @@
 		
 			$('.pp_loaderIcon').show();
 		
+			// Rebuild Facebook Like Button with updated href
+			facebook_like_updated = settings.facebook_like.replace('{location_href}', encodeURIComponent(getUpdatedHref())); 
+			$pp_pic_holder.find('.facebook').html(facebook_like_updated);
+			
 			// Fade the content in
 			if($ppt.is(':hidden')) $ppt.css('opacity',0).show();
 			$pp_overlay.show().fadeTo(settings.animation_speed,settings.opacity);
@@ -717,7 +722,13 @@
 	
 		function _build_overlay(caller){
 			
-			settings.markup=settings.markup.replace('{pp_social}',(settings.social_tools)?settings.social_tools:'');
+			// add current url as href param to default FB markup. 
+			// Works with a copy of settings.facebook_like, we need to original markup intact for when user navigates through photos 
+			facebook_like = settings.facebook_like.replace('{location_href}', encodeURIComponent(location.href)); 
+			// place FB Like's markup into Social Tools markup
+			settings.social_tools = settings.social_tools.replace('{facebook_like}',(facebook_like)?facebook_like:''); 
+			// place Social Tool markup into General markup
+			settings.markup=settings.markup.replace('{pp_social}',(settings.social_tools)?settings.social_tools:''); 
 			
 			$('body').append(settings.markup); // Inject the markup
 			
@@ -855,8 +866,25 @@
 	
 	function setHashtag(){
 		if(typeof theRel == 'undefined') return; // theRel is set on normal calls, it's impossible to deeplink using the API
-		location.hash = '!' + theRel + '/'+rel_index+'/';
+		location.hash = buildHashtag();
 	};
+	
+	/*  
+		returns the updated href with the new hashtag, without actually changing the location.
+		Used to build FB Like button before actually showing the new url in the browser's location bar.	
+	*/
+	function getUpdatedHref(){
+		locCopy = location;
+		locCopy.hash = buildHashtag();
+		return locCopy.href;
+	};
+	
+	/*
+		single function to built Hashtag structure
+	*/
+	function buildHashtag(){
+		return '!' + theRel + '/'+rel_index+'/';
+	}
 	
 	function getParam(name,url){
 	  name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");


### PR DESCRIPTION
FB Like button's href parameter gets updated when browsing through photos.
Also, added encodeUriComponent on that href param, so that we don't lose the hashtag portion anymore.

The FB Like button markup is now in it's own setting variable, independent of the global social_tools setting. I didn't touch twitter markup, but we could eventually get it out too, and eventually add other sharing tools markup.

Let me know if some things are not correctly written.
