### PR TITLE
Images larger than browser window

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -491,7 +491,7 @@
 			// Resize picture the holder
 			$pp_pic_holder.animate({
 				'top': projectedTop,
-				'left': (windowWidth/2) - (pp_dimensions['containerWidth']/2),
+				'left': ((windowWidth/2) - (pp_dimensions['containerWidth']/2) < 0) ? 0 : (windowWidth/2) - (pp_dimensions['containerWidth']/2),
 				width:pp_dimensions['containerWidth']
 			},settings.animation_speed,function(){
 				$pp_pic_holder.find('.pp_hoverContainer,#fullResImage').height(pp_dimensions['height']).width(pp_dimensions['width']);


### PR DESCRIPTION
Hi Stephane,

I posted an issue earlier this evening https://github.com/scaron/prettyphoto/issues/69 about a problem with very large images displayed at full size, in a browser window that is smaller: the left side of the image disappears because the image is always centered.

I added a little fix for this that tests to see if the left: value is less than zero - if it is, it is set to zero. You need to scroll to the right to see the whole image, but then, if the image is REALLY large, you need to do that anyway! :)

Hope that this is the correct way to suggest a fix - it's my first time using github, so hopefully I have not screwed anything up :)

Best regards, and thanks for the absolutely wonderful prettyPhoto!

-Stuart
