### PR TITLE
Fix hashtag on close

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -886,10 +886,7 @@
 	};
 	
 	function clearHashtag(){
-		// Clear the hashtag only if it was set by prettyPhoto
-		url = location.href;
-		hashtag = (url.indexOf('#!prettyPhoto')) ? true : false;
-		if(hashtag!==-1) location.hash = "!prettyPhoto";
+		if ( location.href.indexOf('#!prettyPhoto') !== -1 ) location.hash = "!prettyPhoto";
 	}
 	
 	function getParam(name,url){


### PR DESCRIPTION
The close function was checking to see if the hashtag had been modified by prettyPhoto by checking indexOf. However it was checking to see if indexOf was true, not if it was not -1. -1 evals to true in these circumstances
