### PR TITLE
removed bangs from shebangs

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -885,17 +885,17 @@
 	
 	function getHashtag(){
 		url = location.href;
-		hashtag = (url.indexOf('#!') !== -1) ? decodeURI(url.substring(url.indexOf('#!')+2,url.length)) : false;
+		hashtag = (url.indexOf('#') !== -1) ? decodeURI(url.substring(url.indexOf('#')+2,url.length)) : false;
 		return hashtag;
 	};
 	
 	function setHashtag(){
 		if(typeof theRel == 'undefined') return; // theRel is set on normal calls, it's impossible to deeplink using the API
-		location.hash = '!' + theRel + '/'+rel_index+'/';
+		location.hash = theRel + '/'+rel_index+'/';
 	};
 	
 	function clearHashtag(){
-		if ( location.href.indexOf('#!prettyPhoto') !== -1 ) location.hash = "!prettyPhoto";
+		if ( location.href.indexOf('#prettyPhoto') !== -1 ) location.hash = "prettyPhoto";
 	}
 	
 	function getParam(name,url){


### PR DESCRIPTION
Removed all instances of bang (!) from shebang (#!). This clears up issues with Facebook like service choking on the shebang (#!).
