### PR TITLE
Fixed endless recursion loop bug that caused browser to freeze

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -595,11 +595,13 @@
 					pp_containerHeight = imageHeight, pp_containerWidth = imageWidth;
 				};
 			
-				_getDimensions(imageWidth,imageHeight);
+
 				
 				if((pp_containerWidth > windowWidth) || (pp_containerHeight > windowHeight)){
 					_fitToViewport(pp_containerWidth,pp_containerHeight)
 				};
+				
+				_getDimensions(imageWidth,imageHeight);
 			};
 			
 			return {


### PR DESCRIPTION
Fixed endless recursion loop bug that caused browser to freeze when container is too 'high' because of lengthy pp_description.  To reproduce, use a title attribute that substantially increases container height.  This is a simple fix and does not resize the image to accommodate the lengthly description, so description may go 'off-window'.
