### PR TITLE
specify description attribute src

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,13 @@
 				<li><a href="images/fullscreen/1.jpg" rel="prettyPhoto[gallery2]"><img src="images/thumbnails/t_1.jpg" width="60" height="60" alt="" /></a></li>
 				<li><a href="images/fullscreen/2.jpg" rel="prettyPhoto[gallery2]"><img src="images/thumbnails/t_2.jpg" width="60" height="60" alt="" /></a></li>
 			</ul>
+			
+			<h2>Gallery 3</h2>
+			<ul class="gallery clearfix">
+				<li><a href="images/fullscreen/3.jpg" rel="prettyPhoto[gallery3]" data-description="How is the description on that one? How is the description on that one? How is the description on that one? "><img src="images/thumbnails/t_3.jpg" width="60" height="60" alt="This is a pretty long title" /></a></li>
+				<li><a href="images/fullscreen/4.jpg" rel="prettyPhoto[gallery3]" data-description="Description on a single line."><img src="images/thumbnails/t_4.jpg" width="60" height="60" alt="" /></a></li>
+				<li><a href="images/fullscreen/2.jpg" rel="prettyPhoto[gallery3]" data-description="&lt;a href=&#x27;http://www.google.ca&#x27; target=&#x27;_blank&#x27; &gt;This will open Google.com in a new window&lt;/a&gt;"><img src="images/thumbnails/t_2.jpg" width="60" height="60" alt="" /></a></li>
+			</ul>
 
 			<h2>API Call</h2>
 			<script type="text/javascript" charset="utf-8">
@@ -185,7 +192,8 @@
 				
 				$(".gallery:first a[rel^='prettyPhoto']").prettyPhoto({animation_speed:'normal',theme:'light_square',slideshow:3000, autoplay_slideshow: true});
 				$(".gallery:gt(0) a[rel^='prettyPhoto']").prettyPhoto({animation_speed:'fast',slideshow:10000, hideflash: true});
-		
+				$(".gallery:eq(2) a[rel^='prettyPhoto']").prettyPhoto({description_src:'data-description'});
+				
 				$("#custom_content a[rel^='prettyPhoto']:first").prettyPhoto({
 					custom_markup: '<div id="map_canvas" style="width:260px; height:265px"></div>',
 					changepicturecallback: function(){ initialize(); }

--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -20,6 +20,7 @@
 			allow_expand: true, /* Allow the user to expand a resized image. true/false */
 			default_width: 500,
 			default_height: 344,
+			description_src : 'title', /* which attribute contains the description to be used */
 			counter_separator_label: '/', /* The separator for the gallery counter 1 "of" 2 */
 			theme: 'pp_default', /* light_rounded / dark_rounded / light_square / dark_square / facebook */
 			horizontal_padding: 20, /* The padding on each side of the picture */
@@ -153,7 +154,7 @@
 			// Put the SRCs, TITLEs, ALTs into an array.
 			pp_images = (isSet) ? jQuery.map(matchedObjects, function(n, i){ if($(n).attr(settings.hook).indexOf(theRel) != -1) return $(n).attr('href'); }) : $.makeArray($(this).attr('href'));
 			pp_titles = (isSet) ? jQuery.map(matchedObjects, function(n, i){ if($(n).attr(settings.hook).indexOf(theRel) != -1) return ($(n).find('img').attr('alt')) ? $(n).find('img').attr('alt') : ""; }) : $.makeArray($(this).find('img').attr('alt'));
-			pp_descriptions = (isSet) ? jQuery.map(matchedObjects, function(n, i){ if($(n).attr(settings.hook).indexOf(theRel) != -1) return ($(n).attr('title')) ? $(n).attr('title') : ""; }) : $.makeArray($(this).attr('title'));
+			pp_descriptions = (isSet) ? jQuery.map(matchedObjects, function(n, i){ if($(n).attr(settings.hook).indexOf(theRel) != -1) return ($(n).attr(settings.description_src)) ? $(n).attr(settings.description_src) : ""; }) : $.makeArray($(this).attr(settings.description_src));
 			
 			if(pp_images.length > settings.overlay_gallery_max) settings.overlay_gallery = false;
 			


### PR DESCRIPTION
adding in the ability to specify which element attribute should be used for pulling the description in the lightbox overlay; defaults to title for bc. this allows you to use an html5 custom attribute such as data-description rather than the default title attribute. the use of the html5 custom attribute also allows you to avoid the problem of the title tooltip displaying html markup if that is what you have in the attribute.
