### PR TITLE
Rough fix for _fitToViewport recursion

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -563,6 +563,11 @@
 		function _checkPosition(setCount){
 			(setCount > 1) ? $('.pp_nav').show() : $('.pp_nav').hide(); // Hide the bottom nav if it's not a set.
 		};
+		
+		/**
+		* Anti-recursion counter for _fitToViewport
+		*/
+		var recursionCounter = 0;
 	
 		/**
 		* Resize the item dimensions if it's bigger than the viewport
@@ -598,11 +603,16 @@
 
 				
 				if((pp_containerWidth > windowWidth) || (pp_containerHeight > windowHeight)){
-					_fitToViewport(pp_containerWidth,pp_containerHeight)
+					//I think, that 20 iterations is more than enough for correct calculation
+					if( ++recursionCounter < 20 ){
+						_fitToViewport(pp_containerWidth,pp_containerHeight)
+					}
 				};
 				
 				_getDimensions(imageWidth,imageHeight);
 			};
+
+			recursionCounter = 0;
 			
 			return {
 				width:Math.floor(imageWidth),


### PR DESCRIPTION
In some cases (large picture title with show_title:true, small window size, long picture, etc) prettyPhoto falls into infinite recursion in _fitToViewport function.
This is a quickfix for such situations. 

Of course it'll be much better to detect such cases and fix them somehow, (for example - change the show_title template to absolute positioning) but it's a matter of design/markup and I'm not skill-enough for this :)
