### PR TITLE
fixed xss vulnerability

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -130,7 +130,7 @@
 								break;
 						};
 						// return false;
-					};
+					;}g
 				};
 			});
 		};
@@ -879,7 +879,11 @@
 			hashRel = hashIndex;
 			hashIndex = hashIndex.substring(hashIndex.indexOf('/')+1,hashIndex.length-1);
 			hashRel = hashRel.substring(0,hashRel.indexOf('/'));
-
+			
+			// xss prevention
+			hashIndex = parseInt(hashIndex);
+			hashRel = hashRel.replace(/([ #;&,.+*~\':"!^$[\]()=>|\/])/g,'\\$1');
+			
 			// Little timeout to make sure all the prettyPhoto initialize scripts has been run.
 			// Useful in the event the page contain several init scripts.
 			setTimeout(function(){ $("a["+pp_settings.hook+"^='"+hashRel+"']:eq("+hashIndex+")").trigger('click'); },50);

--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -130,7 +130,7 @@
 								break;
 						};
 						// return false;
-					;}g
+					};
 				};
 			});
 		};


### PR DESCRIPTION
Escape hashRel and parse hashIndex as integer.
Example: `http://www.no-margin-for-errors.com/projects/prettyPhoto-jquery-lightbox-clone/#prettyPhoto[pp_gal]/2,<a onclick="alert(1);">/`
