### PR TITLE
Modified key-binding

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -133,6 +133,8 @@
 					};
 				};
 			});
+		} else {
+			$(document).unbind('keydown.prettyphoto')
 		};
 		
 		/**


### PR DESCRIPTION
Although not always relevant, if prettyPhoto is used on multiple elements on the page, with different filters, the keybinding didn't work as expected for the remaining calls. Once set it couldn't be unbinded, as there was no alternative.
