### PR TITLE
Do not leave "#prettyPhoto" in the URL when closing the lightbox

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -895,7 +895,7 @@
 	};
 	
 	function clearHashtag(){
-		if ( location.href.indexOf('#prettyPhoto') !== -1 ) location.hash = "prettyPhoto";
+		if ( location.href.indexOf('#prettyPhoto') !== -1 ) location.hash = "";
 	}
 	
 	function getParam(name,url){


### PR DESCRIPTION
When opening the prettyPhoto lightbox, #prettyPhoto[pp_gal]/0/ is appended to the URL.
When closing the prettyPhoto lightbox, #prettyPhoto is left